### PR TITLE
Support for `env_vars` config option.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,14 +2,14 @@
 [![Gem Version](https://badge.fury.io/rb/kitchen-goss.svg)](https://badge.fury.io/rb/kitchen-goss)
 [![Gem Downloads](http://ruby-gem-downloads-badge.herokuapp.com/kitchen-goss?type=total&color=brightgreen)](https://rubygems.org/gems/kitchen-goss)
 
-A test-kitchen verifier plugin for GOSS 
+A test-kitchen verifier plugin for GOSS
 
 ## Intro
-[GOSS](https://github.com/aelsabbahy/goss.git) is a tool for validating a server's configuration. 
+[GOSS](https://github.com/aelsabbahy/goss.git) is a tool for validating a server's configuration.
 This kitchen plugin adds Goss support as a validation to kitchen. Since GOSS is written in GO lang. This plugin use sftp to push tests to remote machines no ruby is needed to run verify.
 
 
-## How to install 
+## How to install
 
 ### Ruby gem
 ```
@@ -17,7 +17,7 @@ gem install kitchen-goss
 ```
 
 ### To install from code or develop
-``` 
+```
 git clone git@github.com:ahelal/kitchen-goss.git
 cd kitchen-goss
 gem build kitchen-goss.gemspec
@@ -35,6 +35,8 @@ Besides the normal config in kitchen.yml goss validation can accept the followin
 
 ```ruby
 default_config :sleep, 0
+default_config :use_sudo, false
+default_config :env_vars, {}
 default_config :goss_version, "v0.1.5"
 default_config :validate_output, "documentation"
 default_config :custom_install_command, nil

--- a/lib/kitchen/verifier/goss.rb
+++ b/lib/kitchen/verifier/goss.rb
@@ -13,11 +13,13 @@ module Kitchen
       #
       default_config :sleep, 0
       default_config :use_sudo, false
+      default_config :env_vars, {}
       default_config :goss_version, "v0.1.5"
       default_config :validate_output, "documentation"
       default_config :custom_install_command, nil
       default_config :goss_link, "https://github.com/aelsabbahy/goss/releases/download/$VERSION/goss-${DISTRO}-${ARCH}"
       default_config :goss_download_path, "/tmp/goss-${VERSION}-${DISTRO}-${ARCH}"
+      default_config :goss_tests_dir, nil
 
       def install_command
         # If cutom install
@@ -145,10 +147,18 @@ module Kitchen
         File.join(sandbox_path, "suites")
       end
 
+      def env_vars
+        return nil if config[:env_vars].none?
+        config[:env_vars].map { |k, v| "#{k}=#{v}" }.join(' ')
+      end
+
       # @return [String] the run command to execute tests
       # @api private
       def run_test_command
-        command = config[:use_sudo] == false ? config[:goss_download_path] : "sudo #{config[:goss_download_path]}"
+        command = config[:goss_download_path]
+        command = "sudo -E #{command}" if !config[:use_sudo] == true
+        command = "#{env_vars} #{command}" if !config[:env_vars].none?
+
         <<-CMD
           if [ ! -x "#{config[:goss_download_path]}" ]; then
               echo "Something failed cant execute '${command}'"

--- a/lib/kitchen/verifier/goss.rb
+++ b/lib/kitchen/verifier/goss.rb
@@ -19,7 +19,6 @@ module Kitchen
       default_config :custom_install_command, nil
       default_config :goss_link, "https://github.com/aelsabbahy/goss/releases/download/$VERSION/goss-${DISTRO}-${ARCH}"
       default_config :goss_download_path, "/tmp/goss-${VERSION}-${DISTRO}-${ARCH}"
-      default_config :goss_tests_dir, nil
 
       def install_command
         # If cutom install


### PR DESCRIPTION
Because Goss supports tests based on environment variables, this PR implements an easy way to set them up.